### PR TITLE
A minimal implementation of handling ping not working

### DIFF
--- a/src/main/HeartbeatHandler.ts
+++ b/src/main/HeartbeatHandler.ts
@@ -71,6 +71,16 @@ export class HeartbeatHandler {
 
         let timer: Timer = setInterval( () => {
 
+            if ( this.alive ) {
+                this.alive = false;
+                try {
+                    this.websocket.ping();
+                } catch ( e ) {
+                    // This can occur if the websocket has closed, so lets just catch
+                    // it but keep this.alive = false.
+                }    
+            }
+            
             if( !this.alive ) {
 
                 if( !isNullOrUndefined( this.onDeath ) ) {
@@ -79,11 +89,7 @@ export class HeartbeatHandler {
                 this.websocket.terminate();
                 clearInterval( timer );
                 return;
-
             }
-
-            this.alive = false;
-            this.websocket.ping();
 
         }, this.pingInterval );
 


### PR DESCRIPTION
Twice I've had an error 
`Error: not opened
    at WebSocket.ping (/ws/lib/WebSocket.js:313:13)
    at Timeout.setInterval [as _onTimeout] (//websocket-heartbeats/src/main/HeartbeatHandler.ts:83:28)
    at ontimeout (timers.js:458:11)
    at tryOnTimeout (timers.js:296:5)
    at Timer.listOnTimeout (timers.js:259:5)
`

This is a minimal fix - wrap ping in a try catch, and then check to see whether it needs to cleanup.